### PR TITLE
Add username support

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,4 +1,13 @@
+PRAGMA foreign_keys = ON;
+
 CREATE TABLE assessments (
-  id TEXT NOT NULL,
-  relevant INTEGER -- boolean; if NULL, seen but not assessed
+  id TEXT NOT NULL, -- id of assessed snippet
+  relevant INTEGER, -- boolean; if NULL, seen but not assessed
+  userid INTEGER,
+  FOREIGN KEY(userid) REFERENCES users(userid)
+);
+
+CREATE TABLE users (
+  userid INTEGER PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL
 );

--- a/users.go
+++ b/users.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"regexp"
+
+	"github.com/julienschmidt/httprouter"
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+var validUsername = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+func (s *server) addUser(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	username, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if !validUsername.Match(username) {
+		http.Error(w, fmt.Sprintf("invalid username %q", username), http.StatusBadRequest)
+		return
+	}
+
+	_, err = s.db.Exec(`INSERT INTO users (username) VALUES (?)`, username)
+	if e, ok := err.(sqlite3.Error); ok && e.ExtendedCode == sqlite3.ErrConstraintUnique {
+		http.Error(w, fmt.Sprintf("duplicate username %q", username), http.StatusConflict)
+		return
+	}
+
+	if err != nil {
+		http.Error(w, "database error", http.StatusInternalServerError)
+		log.Print(err)
+		return
+	}
+}
+
+func (s *server) listUsers(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		http.Error(w, "database error", http.StatusInternalServerError)
+		log.Print(err)
+		return
+	}
+
+	defer func() {
+		if err != nil {
+			rollback(w, tx, err)
+		}
+	}()
+
+	rows, err := tx.Query(`SELECT username FROM users`)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	var (
+		username  string
+		usernames []string
+	)
+	for rows.Next() {
+		rows.Scan(&username)
+		usernames = append(usernames, username)
+	}
+	if err = rows.Err(); err != nil {
+		return
+	}
+
+	tx.Commit()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(usernames)
+}
+
+func getUsername(r *http.Request) (username string, err error) {
+	// For the moment, we have a custom "authorization" header that contains just
+	// "Username <username>". We can upgrade this to Basic-Auth or something fancy later.
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		err = errors.New("no username provided")
+		return
+	}
+
+	_, err = fmt.Sscanf(auth, "Username %s\n", &username)
+	if err != nil {
+		err = errors.New("invalid Authorization header")
+	}
+	return
+}

--- a/users_test.go
+++ b/users_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddUser(t *testing.T) {
+	db := newDatabase(t)
+	defer db.Close()
+
+	r := httprouter.New()
+	newServer(db, "", "", r)
+
+	req := httptest.NewRequest("POST", "/users", strings.NewReader("test1"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Duplicate username.
+	req = httptest.NewRequest("POST", "/users", strings.NewReader("test1"))
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	resp = w.Result()
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+
+	req = httptest.NewRequest("GET", "/users", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	resp = w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", w.HeaderMap.Get("Content-Type"))
+
+	dec := json.NewDecoder(resp.Body)
+	var usernames []string
+	err := dec.Decode(&usernames)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"test1"}, usernames)
+}


### PR DESCRIPTION
Usernames don't currently come with passwords and anyone can add a user via a POST request.

Also moved the prepared statements closer to their use for readability and fixed some transaction code.